### PR TITLE
Add eslint plugin to detect implicit dependencies

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -17,6 +17,7 @@ module.exports = {
         node: true
     },
     plugins: [
+        'implicit-dependencies',
         'filenames',
         'one-variable-per-var',
         'mocha'

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "eslint": "^3.6.1",
     "eslint-plugin-filenames": "^1.0.0",
+    "eslint-plugin-implicit-dependencies": "^1.0.2",
     "eslint-plugin-mocha": "^4.5.1",
     "eslint-plugin-one-variable-per-var": "0.0.3"
   }

--- a/rules/plugins.js
+++ b/rules/plugins.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     'filenames/match-regex': [2, '^(<text>$|[a-z\-\.]+$)'],
-    'one-variable-per-var/one-variable-per-var': 2
+    'one-variable-per-var/one-variable-per-var': 2,
+    'implicit-dependencies/no-implicit': 2
   }
 };

--- a/rules/testing.js
+++ b/rules/testing.js
@@ -6,6 +6,7 @@ module.exports = {
     'max-nested-callbacks': 0,
     'no-unused-expressions': 0,
     'no-process-env': 0,
-    'no-console': 0
+    'no-console': 0,
+    'implicit-dependencies/no-implicit': [2, { dev: true }]
   }
 };


### PR DESCRIPTION
Implicit dependencies are where code calls `require('modulename')` but without having `modulename` listed as a dependency of any kind. This generally occurs when said module is already installed as a child of something else in the dependency tree, so is present in ./node_modules.

However, this causes code to become fragile as it is dependent on the exact structure of the dependency tree, which is liable to change uncontrollably and unexpectedly. In particular, if a module is loaded as a dev dependency (or descendant of a dev dependency) it will not be present following a production install and so may cause code that has passed CI to fail in a prod environment.

By ensuring that all dependencies are explicitly declared in package.json we can remove this risk.