### PR TITLE
Add `no-const-assign` rule

### DIFF
--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -5,6 +5,7 @@ module.exports = {
     'comma-dangle': 0,
     'no-cond-assign': 2,
     'no-console': 2,
+    'no-const-assign': 2,
     'no-constant-condition': 2,
     'no-control-regex': 2,
     'no-debugger': 2,


### PR DESCRIPTION
This will cause a runtime error if a constant has a value assigned, so should be checked against.