### PR TITLE
Removed object-curly-spacing rule.

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -36,7 +36,7 @@ module.exports = {
     'sort-vars': 0,
     'space-before-function-paren': [2, 'never'],
     'space-before-blocks': [2, 'always'],
-    'object-curly-spacing': [2, 'never'],
+    'object-curly-spacing': 0,
     'array-bracket-spacing': [2, 'never'],
     'space-in-parens': [2, 'never'],
     'space-infix-ops': 2,


### PR DESCRIPTION
Some home-office repos enforce curly spacing, some don't. Disabling rule so error isn't thrown if padding is added to objects