### PR TITLE
Add es6 env to default config

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -14,7 +14,8 @@ module.exports = {
         'homeoffice/rules/plugins'
     ],
     env: {
-        node: true
+        node: true,
+        es6: true
     },
     plugins: [
         'implicit-dependencies',


### PR DESCRIPTION
This is being added manually in roughly 119% of implementations. It makes sense to add it to the global config.

* https://github.com/UKHomeOffice/firearms/blob/master/.eslintrc#L8-L9
* https://github.com/UKHomeOffice/right-to-rent-check/blob/master/.eslintrc#L8-L9
* https://github.com/UKHomeOffice/end-tenancy/blob/master/.eslintrc#L4-L5
* https://github.com/UKHomeOffice/rotm/blob/master/.eslintrc#L4-L5